### PR TITLE
Pull request

### DIFF
--- a/server-main/.classpath
+++ b/server-main/.classpath
@@ -5,6 +5,10 @@
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
-	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/server-main/.project
+++ b/server-main/.project
@@ -6,7 +6,17 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
@@ -17,7 +27,10 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
+		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 	</natures>
 </projectDescription>

--- a/server-main/pom.xml
+++ b/server-main/pom.xml
@@ -26,6 +26,23 @@
       <artifactId>server-interface</artifactId>
       <version>${powertac.version}</version>
     </dependency>
+    
+    <!-- Transitive dependencies of the ActiveMQ (to avoid older ones from ActiveMQ) -->
+	<dependency>
+		<groupId>org.springframework</groupId>
+		<artifactId>org.springframework.beans</artifactId>
+		<version>3.0.6.RELEASE</version>
+	</dependency>
+	<dependency>
+		<groupId>org.springframework</groupId>
+		<artifactId>org.springframework.core</artifactId>
+		<version>3.0.6.RELEASE</version>
+	</dependency>
+	<dependency>
+		<groupId>org.springframework</groupId>
+		<artifactId>org.springframework.context</artifactId>
+		<version>3.0.6.RELEASE</version>
+	</dependency>
 
     <!-- ActiveMQ -->
     <dependency>
@@ -89,7 +106,7 @@
       <artifactId>household-customer</artifactId>
       <version>${powertac.version}</version>
     </dependency>
-    <dependency>
+    <dependency> 
       <groupId>org.powertac</groupId>
       <artifactId>factored-customer</artifactId>
       <version>${powertac.version}</version>


### PR DESCRIPTION
I've added couple of dependencies in the pom.xml file. This blocks outdated transitive dependencies from ActiveMQ dependencies which cause problems with the Visualizer. 

LogService:
- added folder path property and setter
- changed startLog
- refactored getRootLogger() to getPowertacLogger() - That way we are logging messages only from org.powertac package. Also, this way we won't stop/disable appenders from the root logger (important for web-app debugging).

Cheers,
Jurica
