### PR TITLE
Add sonatype repository for snapshot distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,16 @@
   </parent>
 
 
+  <!-- Sonatype OSS repo for resolving snapshot dependencies -->
+
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+
+
   <!-- server components -->
   <modules>
     <module>server-interface</module>

--- a/server-master/pom.xml
+++ b/server-master/pom.xml
@@ -23,6 +23,16 @@
   </parent>
 
 
+  <!-- Sonatype OSS repo for resolving snapshot dependencies -->
+
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+
+
   <!-- Common dependencies across all server modules -->
 
   <dependencies>


### PR DESCRIPTION
I intended this to be inherited from powertac-parent, but of course that doesn't work when it doesn't already have powertac-parent locally and we're not telling mvn where to find it.