### PR TITLE
Revert "#653 - clean up after PowerType changes"

### DIFF
--- a/visualizer/src/main/java/org/powertac/visualizer/user/TariffMarketBean.java
+++ b/visualizer/src/main/java/org/powertac/visualizer/user/TariffMarketBean.java
@@ -69,7 +69,7 @@ public class TariffMarketBean implements Serializable
             put(PowerType.PUMPED_STORAGE_PRODUCTION, 0l);
             put(PowerType.RUN_OF_RIVER_PRODUCTION, 0l);
             put(PowerType.SOLAR_PRODUCTION, 0l);
-            //put(PowerType.STORAGE, 0l);
+            put(PowerType.STORAGE, 0l);
             put(PowerType.THERMAL_STORAGE_CONSUMPTION, 0l);
             put(PowerType.WIND_PRODUCTION, 0l);
           }
@@ -129,8 +129,8 @@ public class TariffMarketBean implements Serializable
               .get(PowerType.WIND_PRODUCTION)));
 
       ArrayList<Object> data_s = new ArrayList<Object>();
-      //data_s.add(new PowerTypeTemplate("Storage", customerTypeSpecific
-      //        .get(PowerType.STORAGE)));
+      data_s.add(new PowerTypeTemplate("Storage", customerTypeSpecific
+              .get(PowerType.STORAGE)));
       data_s.add(new PowerTypeTemplate("Battery storage", customerTypeSpecific
               .get(PowerType.BATTERY_STORAGE)));
       data_s.add(new PowerTypeTemplate("Electric vehicle", customerTypeSpecific


### PR DESCRIPTION
This reverts commit b46e975b5fa6acc2c91aba1dd26283b94f782704.

I've tested -Pweb with this in place, seems to fix Imbhat's issue. Thanks John!

Not sure what's the best way to get this out, can we re-release visualizer 1.4.1 as in overwrite it on sonatype/mvncentral? Or would it have to be 1.4.2?

Ref. https://github.com/powertac/powertac-server/issues/923#issuecomment-290117167