### PR TITLE
Turn off state/trace logs while replaying games

### DIFF
--- a/logtool-core/src/main/java/org/powertac/logtool/LogtoolCore.java
+++ b/logtool-core/src/main/java/org/powertac/logtool/LogtoolCore.java
@@ -61,7 +61,8 @@ public class LogtoolCore
   private DomainBuilder builder;
 
   private boolean simEnd = false;
-  
+  private boolean isInterrupted = false;
+
   static private CompressorStreamFactory compressFactory = new CompressorStreamFactory();
   static private ArchiveStreamFactory archiveFactory = new ArchiveStreamFactory();
 
@@ -163,6 +164,8 @@ public class LogtoolCore
     log.info("Reading state log from stream for {}",
              tools[0].getClass().getName());
     simEnd = false;
+    isInterrupted = false;
+
     try {
       // Stack compression logic if appropriate
       try {
@@ -208,6 +211,12 @@ public class LogtoolCore
       BufferedReader in = new BufferedReader(inputReader);
       int lineNumber = 0;
       while (!simEnd) {
+        synchronized(this) {
+          if (isInterrupted) {
+            in.close();
+            break;
+          }
+        }
         line = in.readLine();
         if (null == line) {
           log.info("Last line " + lineNumber);
@@ -230,6 +239,9 @@ public class LogtoolCore
     return null;
   }
 
+  public synchronized void interrupt() {
+    isInterrupted = true;
+  }
 
   class SimEndHandler implements NewObjectListener
   {

--- a/logtool-core/src/main/java/org/powertac/logtool/common/DomainObjectReader.java
+++ b/logtool-core/src/main/java/org/powertac/logtool/common/DomainObjectReader.java
@@ -291,7 +291,7 @@ public class DomainObjectReader
   {
     Instant value = Instant.parse(time);
     timeService.setCurrentTime(value);
-    log.info("time set to " + time);
+    log.debug("time set to " + time);
   }
   
   private void fireNewObjectEvent (Object thing)

--- a/visualizer2/src/main/java/org/powertac/visualizer/logtool/LogtoolExecutor.java
+++ b/visualizer2/src/main/java/org/powertac/visualizer/logtool/LogtoolExecutor.java
@@ -48,6 +48,12 @@ public class LogtoolExecutor extends NoopAnalyzer {
         log.info("Finished replay of " + logName);
     }
 
+    public void interrupt() {
+      getCore().interrupt();
+      log.info("Interrupted replay of " + logName);
+    }
+    
+
     // This suppresses all events until the first TimeslotUpdate. At that point
     // it sends the current competition object, and commences forwarding all
     // events from there on out.


### PR DESCRIPTION
I noticed that logs get extremely large when replaying a bunch of games -- turns out the visualizer was reproducing the state/trace logs in its own logfiles. So this PR shuts up the viz loggers while replaying and turns them back on when done.