### PR TITLE
Try openjdk instead of oracle, travis fails otherwise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - linux
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
Hi John,

Hope you're well.

Trying to make PRs for security alerts, I notice there is a problem on Travis CI with oraclejdk. So this changes it to openjdk, just to get the build to pass. If you agree and merge this, I will rebase my other branches and submit PRs off of those.

In the meantime I'll try to get things working with Java11.

gr
Erik
