### PR TITLE
More transient dependency exclusions

### DIFF
--- a/visualizer2/pom.xml
+++ b/visualizer2/pom.xml
@@ -246,18 +246,34 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-json</artifactId>
-            <version>${dropwizard-metrics.version}</version>
+	    <version>${dropwizard-metrics.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>metrics-core</artifactId>
+                    <groupId>io.dropwizard.metrics</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jvm</artifactId>
-            <version>${dropwizard-metrics.version}</version>
+	    <version>${dropwizard-metrics.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>metrics-core</artifactId>
+                    <groupId>io.dropwizard.metrics</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-servlet</artifactId>
 	    <version>${dropwizard-metrics.version}</version>
-            <exclusions>
+	    <exclusions>
+                <exclusion>
+                    <artifactId>metrics-core</artifactId>
+                    <groupId>io.dropwizard.metrics</groupId>
+                </exclusion>
                 <exclusion>
                     <groupId>io.dropwizard.metrics</groupId>
                     <artifactId>metrics-json</artifactId>
@@ -271,17 +287,37 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-servlets</artifactId>
-            <version>${dropwizard-metrics.version}</version>
+	    <version>${dropwizard-metrics.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>metrics-core</artifactId>
+                    <groupId>io.dropwizard.metrics</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-jvm</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
-            <version>${prometheus-simpleclient.version}</version>
+	    <version>${prometheus-simpleclient.version}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_dropwizard</artifactId>
-            <version>${prometheus-simpleclient.version}</version>
+	    <version>${prometheus-simpleclient.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>metrics-core</artifactId>
+                    <groupId>io.dropwizard.metrics</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>


### PR DESCRIPTION
@jecollins 
Strange that it didn't throw up these errors the first time. Perhaps it did not get that far due to the earlier errors.

That also means that there might be still more of these popping up with this change in. I hope you see the pattern of what I'm doing: it complains about a transient dependency which has an earlier version than the one we explicitly list as a direct dependency. The "fix" (*) is to exclude the transient dependency, within the parent, in visualizer2/pom.xml

I really have to call it a day now... It's been a long day, and it looks like starting tomorrow we have to drop everything and start work on a "corona app". Never let a good crisis...

(*) I'm pretty sure maven semantics are clear that the "nearest" dependency wins, in case of different versions, which would be the explicit one in our pom rather than the transient one we get indirectly via some other dependency. No other plugin complains about this, except mvn site.