### PR TITLE
Fix constraint violation of DemandElement distribution

### DIFF
--- a/customer-models/src/main/java/org/powertac/customer/evcharger/DemandSampler.java
+++ b/customer-models/src/main/java/org/powertac/customer/evcharger/DemandSampler.java
@@ -169,8 +169,6 @@ class DemandSampler
     HashMap<Integer, TreeMap<Integer, Integer>> cohortChargerHoursHistogram = new HashMap<>();
     // Tracks the number of vehicles in each cohort.
     HashMap<Integer, Integer> cohortVehicleSum = new HashMap<>();
-    // Tracks the total energy demand in each cohort.
-    HashMap<Integer, Double> cohortEnergySum = new HashMap<>();
 
     // We need to initialize all cohorts until maxHorizon and
     // maxChargerHours respectively to avoid gaps in the HashMap indices.
@@ -190,7 +188,6 @@ class DemandSampler
         cohortChargerHoursHistogram.get(i).put(j, 0);
       }
       cohortVehicleSum.put(i, 0);
-      cohortEnergySum.put(i, 0.0);
     }
 
     // Now, we fill in the the values for the charger hour histograms, vehicle
@@ -204,13 +201,11 @@ class DemandSampler
       cohortChargerHoursHistogram.put(horizon, histogram);
 
       cohortVehicleSum.merge(horizon, 1, Integer::sum);
-      cohortEnergySum.merge(horizon, energy, Double::sum);
     }
 
     return cohortVehicleSum.keySet().stream()
-            .map(horizon -> new DemandElement(horizon, cohortVehicleSum.get(horizon), cohortEnergySum.get(horizon),
-                                              cohortChargerHoursHistogram.get(horizon).values().stream()
-                                                      .mapToDouble(Integer::doubleValue).toArray()))
+            .map(horizon -> new DemandElement(horizon, cohortVehicleSum
+                    .get(horizon), cohortChargerHoursHistogram.get(horizon).values().stream().mapToDouble(Integer::doubleValue).toArray()))
             .collect(Collectors.toList());
   }
 

--- a/customer-models/src/main/java/org/powertac/customer/evcharger/DemandSampler.java
+++ b/customer-models/src/main/java/org/powertac/customer/evcharger/DemandSampler.java
@@ -196,12 +196,15 @@ class DemandSampler
     // Now, we fill in the the values for the charger hour histograms, vehicle
     // sum and energy sum of each cohort.
     for (double[] horizonEnergyTuple: horizonEnergyTuples) {
-      TreeMap<Integer, Integer> histogram = cohortChargerHoursHistogram.get((int) horizonEnergyTuple[0]);
-      histogram.merge((int) (horizonEnergyTuple[1] / chargerCapacity), 1, Integer::sum);
-      cohortChargerHoursHistogram.put((int) horizonEnergyTuple[0], histogram);
+      int horizon = (int) horizonEnergyTuple[0];
+      double energy = horizonEnergyTuple[1];
+      int chargerHours = (int) (energy / chargerCapacity);
+      TreeMap<Integer, Integer> histogram = cohortChargerHoursHistogram.get(horizon);
+      histogram.merge(Math.min(chargerHours, horizon), 1, Integer::sum);
+      cohortChargerHoursHistogram.put(horizon, histogram);
 
-      cohortVehicleSum.merge((int) horizonEnergyTuple[0], 1, Integer::sum);
-      cohortEnergySum.merge((int) horizonEnergyTuple[0], horizonEnergyTuple[1], Double::sum);
+      cohortVehicleSum.merge(horizon, 1, Integer::sum);
+      cohortEnergySum.merge(horizon, energy, Double::sum);
     }
 
     return cohortVehicleSum.keySet().stream()

--- a/customer-models/src/test/java/org/powertac/customer/evcharger/DemandSamplerTest.java
+++ b/customer-models/src/test/java/org/powertac/customer/evcharger/DemandSamplerTest.java
@@ -132,8 +132,6 @@ class DemandSamplerTest
     final double expectedMaxEnergy = Arrays.stream(expectedHorizonEnergyTuples)
             .mapToDouble(horizonEnergyTuple -> horizonEnergyTuple[1]).max().getAsDouble();
     final int expectedMaxChargerHours = (int) (expectedMaxEnergy / CHARGER_CAPACITY);
-    final double expectedTotalEnergy =
-      Arrays.stream(expectedHorizonEnergyTuples).mapToDouble(horizonEnergyTuple -> horizonEnergyTuple[1]).sum();
 
     List<DemandElement> demandElements = demandSampler.sample(hod, POP_SIZE, CHARGER_CAPACITY);
 
@@ -145,17 +143,13 @@ class DemandSamplerTest
     // the index is the amount of charger hours needed and the value the number
     // of vehicles in that group. These should be maxChargerHours + 1 elements.
     for (DemandElement demandElement: demandElements) {
-      assertEquals(expectedMaxChargerHours + 1, demandElement.getDistribution().length);
+      assertEquals(expectedMaxChargerHours + 1, demandElement.getdistribution().length);
       // The distribution is not allowed to contain vehicles who need more charger hours 
       // than the max horizon allows.
-      for (int i = demandElement.getHorizon() + 1; i < demandElement.getDistribution().length; i++) {
-        assertEquals(0.0, demandElement.getDistribution()[i]);
+      for (int i = demandElement.getHorizon() + 1; i < demandElement.getdistribution().length; i++) {
+        assertEquals(0.0, demandElement.getdistribution()[i]);
       }
     }
-    // The total energy of all DemandElement instances should be the sum of
-    // energy of horizonEnergyTuple samples. We set double precision to 1e-4.
-    assertEquals(expectedTotalEnergy,
-                 demandElements.stream().mapToDouble(demandElement -> demandElement.getEnergy()).sum(), 1e-4);
   }
 
   @Test

--- a/customer-models/src/test/java/org/powertac/customer/evcharger/DemandSamplerTest.java
+++ b/customer-models/src/test/java/org/powertac/customer/evcharger/DemandSamplerTest.java
@@ -146,6 +146,11 @@ class DemandSamplerTest
     // of vehicles in that group. These should be maxChargerHours + 1 elements.
     for (DemandElement demandElement: demandElements) {
       assertEquals(expectedMaxChargerHours + 1, demandElement.getDistribution().length);
+      // The distribution is not allowed to contain vehicles who need more charger hours 
+      // than the max horizon allows.
+      for (int i = demandElement.getHorizon() + 1; i < demandElement.getDistribution().length; i++) {
+        assertEquals(0.0, demandElement.getDistribution()[i]);
+      }
     }
     // The total energy of all DemandElement instances should be the sum of
     // energy of horizonEnergyTuple samples. We set double precision to 1e-4.


### PR DESCRIPTION
In rare cases the model yields (horizon, energy) tuples where the needed energy in charger hours exceeds the horizon which leads to an invalid charger hour histogram.

This pull request fixes this violation and redistributes the invalid demand to the largest valid charger hour group in the histogram.