### PR TITLE
Implement a random seed generator in DemandSampler 

### DIFF
--- a/customer-models/src/main/java/org/powertac/customer/evcharger/DemandElement.java
+++ b/customer-models/src/main/java/org/powertac/customer/evcharger/DemandElement.java
@@ -16,6 +16,7 @@
 package org.powertac.customer.evcharger;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Immutable data carrier, represents the energy need for some number of vehicles that
@@ -116,5 +117,31 @@ class DemandElement // package visibility
   public String toString ()
   {
     return String.format("(h%d,n%.3f,e%s%n)", horizon, nVehicles, Arrays.toString(distribution));
+  }
+  
+  @Override
+  public int hashCode ()
+  {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + Arrays.hashCode(distribution);
+    result = prime * result + Objects.hash(horizon, nVehicles);
+    return result;
+  }
+
+  @Override
+  public boolean equals (Object obj)
+  {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DemandElement other = (DemandElement) obj;
+    return Arrays.equals(distribution, other.distribution)
+           && horizon == other.horizon
+           && Double.doubleToLongBits(nVehicles) == Double
+                   .doubleToLongBits(other.nVehicles);
   }
 }

--- a/customer-models/src/main/java/org/powertac/customer/evcharger/EvCharger.java
+++ b/customer-models/src/main/java/org/powertac/customer/evcharger/EvCharger.java
@@ -138,7 +138,7 @@ public class EvCharger extends AbstractCustomer implements CustomerModelAccessor
     defaultCapacityProfile = new double[] {3.0,3.0,3.0,3.0,3.0,3.0,3.0,4.0,4.0,4.0,3.0,3.0,
                                            4.0,4.0,4.0,4.0,4.0,4.0,5.0,6.0,7.0,6.0,5.0,4.0};
     demandSampler = new DemandSampler();
-    demandSampler.initialize(model);
+    demandSampler.initialize(model, getDemandSeed());
   }
 
   // called from CustomerModelService after initialization


### PR DESCRIPTION
based on `org.powertac.common.RandomSeed` which generates the same sequence of
random seeds each timeslot given the same `org.powertac.common.RandomSeed`
object. This allows for reproducible experiments.